### PR TITLE
feat: scoped clause management UI for agents with tooltip and modal r…

### DIFF
--- a/apps/backend/scripts/test-agent-api.ts
+++ b/apps/backend/scripts/test-agent-api.ts
@@ -1,0 +1,56 @@
+/**
+ * Test script to verify agent API returns scopedAssessments
+ *
+ * To run:
+ * ts-node apps/backend/scripts/test-agent-api.ts
+ */
+
+async function testAgentApi() {
+  try {
+    console.log('Fetching agents from API...');
+    const response = await fetch('http://localhost:3001/api/agents');
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+
+    const agents = await response.json();
+    console.log(`Retrieved ${agents.length} agents`);
+
+    // Check for scopedAssessments
+    if (agents.length > 0) {
+      const firstAgent = agents[0];
+      console.log(
+        'First agent structure:',
+        JSON.stringify(
+          {
+            id: firstAgent.id,
+            name: firstAgent.name,
+            hasClausesArray: Array.isArray(firstAgent.clauses),
+            hasScopedAssessments: Array.isArray(firstAgent.scopedAssessments),
+            scopedAssessmentsCount: firstAgent.scopedAssessments?.length || 0,
+          },
+          null,
+          2,
+        ),
+      );
+
+      // Log the first assessment if available
+      if (
+        firstAgent.scopedAssessments &&
+        firstAgent.scopedAssessments.length > 0
+      ) {
+        console.log(
+          'First assessment:',
+          JSON.stringify(firstAgent.scopedAssessments[0], null, 2),
+        );
+      }
+    }
+
+    console.log('Test completed successfully!');
+  } catch (error) {
+    console.error('Error testing agent API:', error);
+  }
+}
+
+testAgentApi();

--- a/apps/backend/src/aims/aims.module.ts
+++ b/apps/backend/src/aims/aims.module.ts
@@ -6,11 +6,14 @@ import { Agent } from './entities/agent.entity';
 import { ClauseController } from './controllers/clause.controller';
 import { ClauseService } from './services/clause.service';
 import { Clause } from './entities/clause.entity';
+import { AgentClauseAssessment } from './entities/agent-clause-assessment.entity';
+import { AgentClauseAssessmentController } from './controllers/agent-clause-assessment.controller';
+import { AgentClauseAssessmentService } from './services/agent-clause-assessment.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Agent, Clause])],
-  controllers: [AgentController, ClauseController],
-  providers: [AgentService, ClauseService],
-  exports: [AgentService, ClauseService],
+  imports: [TypeOrmModule.forFeature([Agent, Clause, AgentClauseAssessment])],
+  controllers: [AgentController, ClauseController, AgentClauseAssessmentController],
+  providers: [AgentService, ClauseService, AgentClauseAssessmentService],
+  exports: [AgentService, ClauseService, AgentClauseAssessmentService],
 })
 export class AimsModule {}

--- a/apps/backend/src/aims/controllers/agent-clause-assessment.controller.ts
+++ b/apps/backend/src/aims/controllers/agent-clause-assessment.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Post,
+  Body,
+  Param,
+  Patch,
+  Delete,
+} from '@nestjs/common';
+import { AgentClauseAssessmentService } from '../services/agent-clause-assessment.service';
+import { AgentClauseAssessment } from '../entities/agent-clause-assessment.entity';
+import { CreateAgentClauseAssessmentDto } from '../dto/create-agent-clause-assessment.dto';
+import { UpdateAgentClauseAssessmentDto } from '../dto/update-agent-clause-assessment.dto';
+
+@Controller('agent-clause-assessments')
+export class AgentClauseAssessmentController {
+  constructor(
+    private readonly assessmentService: AgentClauseAssessmentService,
+  ) {}
+
+  @Get()
+  findAll(
+    @Query('agentId') agentId?: string,
+    @Query('clauseId') clauseId?: string,
+  ): Promise<AgentClauseAssessment[]> {
+    return this.assessmentService.findAll(agentId, clauseId);
+  }
+
+  @Post()
+  create(
+    @Body() createDto: CreateAgentClauseAssessmentDto,
+  ): Promise<AgentClauseAssessment> {
+    return this.assessmentService.create(createDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.assessmentService.remove(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateDto: UpdateAgentClauseAssessmentDto,
+  ): Promise<AgentClauseAssessment> {
+    return this.assessmentService.update(id, updateDto);
+  }
+}

--- a/apps/backend/src/aims/controllers/agent.controller.ts
+++ b/apps/backend/src/aims/controllers/agent.controller.ts
@@ -10,6 +10,7 @@ import {
 import { AgentService } from '../services/agent.service';
 import { CreateAgentDto } from '../dto/create-agent.dto';
 import { UpdateAgentDto } from '../dto/update-agent.dto';
+import { Agent } from '../entities/agent.entity';
 
 @Controller('agents')
 export class AgentController {
@@ -21,13 +22,15 @@ export class AgentController {
   }
 
   @Get()
-  findAll() {
-    return this.agentService.findAll();
+  async findAll() {
+    const agents = await this.agentService.findAll();
+    return agents.map((agent) => this.transformAgentResponse(agent));
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.agentService.findOne(id);
+  async findOne(@Param('id') id: string) {
+    const agent = await this.agentService.findOne(id);
+    return this.transformAgentResponse(agent);
   }
 
   @Patch(':id')
@@ -38,5 +41,14 @@ export class AgentController {
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.agentService.remove(id);
+  }
+
+  // Helper method to transform agent response for frontend
+  private transformAgentResponse(agent: Agent) {
+    const { assessments, ...rest } = agent;
+    return {
+      ...rest,
+      scopedAssessments: assessments,
+    };
   }
 }

--- a/apps/backend/src/aims/dto/agent-clause-assessment.dto.ts
+++ b/apps/backend/src/aims/dto/agent-clause-assessment.dto.ts
@@ -1,0 +1,21 @@
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class AgentClauseAssessmentDto {
+  @IsUUID()
+  id: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  agentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  clauseId: string;
+
+  @IsString()
+  @IsOptional()
+  evidenceLink?: string;
+
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/apps/backend/src/aims/dto/create-agent-clause-assessment.dto.ts
+++ b/apps/backend/src/aims/dto/create-agent-clause-assessment.dto.ts
@@ -1,0 +1,5 @@
+export class CreateAgentClauseAssessmentDto {
+  agentId: string;
+  clauseId: string;
+  evidenceLink: string;
+}

--- a/apps/backend/src/aims/dto/update-agent-clause-assessment.dto.ts
+++ b/apps/backend/src/aims/dto/update-agent-clause-assessment.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAgentClauseAssessmentDto } from './create-agent-clause-assessment.dto';
+
+export class UpdateAgentClauseAssessmentDto extends PartialType(
+  CreateAgentClauseAssessmentDto,
+) {}

--- a/apps/backend/src/aims/entities/agent-clause-assessment.entity.ts
+++ b/apps/backend/src/aims/entities/agent-clause-assessment.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Agent } from './agent.entity';
+import { Clause } from './clause.entity';
+
+@Entity('agent_clause_assessments')
+export class AgentClauseAssessment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'agent_id' })
+  agentId: string;
+
+  @Column({ name: 'clause_id' })
+  clauseId: string;
+
+  @Column({ name: 'evidence_link', type: 'text', nullable: true })
+  evidenceLink: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ManyToOne(() => Agent, (agent) => agent.assessments)
+  @JoinColumn({ name: 'agent_id' })
+  agent: Agent;
+
+  @ManyToOne(() => Clause, (clause) => clause.assessments)
+  @JoinColumn({ name: 'clause_id' })
+  clause: Clause;
+}

--- a/apps/backend/src/aims/entities/agent.entity.ts
+++ b/apps/backend/src/aims/entities/agent.entity.ts
@@ -5,8 +5,10 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToMany,
+  OneToMany,
 } from 'typeorm';
 import { Clause } from './clause.entity';
+import { AgentClauseAssessment } from './agent-clause-assessment.entity';
 
 @Entity('agents')
 export class Agent {
@@ -33,6 +35,11 @@ export class Agent {
 
   @ManyToMany(() => Clause, (clause) => clause.agents)
   clauses: Clause[];
+
+  @OneToMany(() => AgentClauseAssessment, (assessment) => assessment.agent, {
+    cascade: true,
+  })
+  assessments: AgentClauseAssessment[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/apps/backend/src/aims/entities/clause.entity.ts
+++ b/apps/backend/src/aims/entities/clause.entity.ts
@@ -1,5 +1,13 @@
-import { Column, Entity, PrimaryColumn, ManyToMany, JoinTable } from 'typeorm';
+import {
+  Column,
+  Entity,
+  PrimaryColumn,
+  ManyToMany,
+  JoinTable,
+  OneToMany,
+} from 'typeorm';
 import { Agent } from './agent.entity';
+import { AgentClauseAssessment } from './agent-clause-assessment.entity';
 
 export enum ClauseStatus {
   GAP = 'gap',
@@ -35,6 +43,9 @@ export class Clause {
   @ManyToMany(() => Agent, (agent) => agent.clauses)
   @JoinTable()
   agents: Agent[];
+
+  @OneToMany(() => AgentClauseAssessment, (assessment) => assessment.clause)
+  assessments: AgentClauseAssessment[];
 
   @Column({ default: () => 'CURRENT_TIMESTAMP' })
   createdAt: Date;

--- a/apps/backend/src/aims/services/agent-clause-assessment.service.ts
+++ b/apps/backend/src/aims/services/agent-clause-assessment.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AgentClauseAssessment } from '../entities/agent-clause-assessment.entity';
+import { CreateAgentClauseAssessmentDto } from '../dto/create-agent-clause-assessment.dto';
+import { UpdateAgentClauseAssessmentDto } from '../dto/update-agent-clause-assessment.dto';
+import { Agent } from '../entities/agent.entity';
+import { Clause } from '../entities/clause.entity';
+
+@Injectable()
+export class AgentClauseAssessmentService {
+  constructor(
+    @InjectRepository(AgentClauseAssessment)
+    private readonly assessmentRepository: Repository<AgentClauseAssessment>,
+
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+
+    @InjectRepository(Clause)
+    private readonly clauseRepo: Repository<Clause>,
+  ) {}
+
+  async findAll(
+    agentId?: string,
+    clauseId?: string,
+  ): Promise<AgentClauseAssessment[]> {
+    const whereCondition: any = {};
+
+    if (agentId) {
+      whereCondition.agentId = agentId;
+    }
+
+    if (clauseId) {
+      whereCondition.clauseId = clauseId;
+    }
+
+    return this.assessmentRepository.find({
+      where:
+        Object.keys(whereCondition).length > 0 ? whereCondition : undefined,
+      relations: ['agent', 'clause'],
+    });
+  }
+
+  async create(
+    dto: CreateAgentClauseAssessmentDto,
+  ): Promise<AgentClauseAssessment> {
+    const agent = await this.agentRepo.findOneByOrFail({ id: dto.agentId });
+    const clause = await this.clauseRepo.findOneByOrFail({
+      id: dto.clauseId,
+    });
+
+    const assessment = this.assessmentRepository.create({
+      agent,
+      clause,
+      evidenceLink: dto.evidenceLink,
+    });
+
+    return this.assessmentRepository.save(assessment);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.assessmentRepository.delete(id);
+  }
+
+  async update(
+    id: string,
+    updateDto: UpdateAgentClauseAssessmentDto,
+  ): Promise<AgentClauseAssessment> {
+    const assessment = await this.assessmentRepository.findOne({
+      where: { id },
+      relations: ['agent', 'clause'],
+    });
+
+    if (!assessment) {
+      throw new NotFoundException(`Assessment with ID ${id} not found`);
+    }
+
+    Object.assign(assessment, updateDto);
+    return this.assessmentRepository.save(assessment);
+  }
+}

--- a/apps/backend/src/aims/services/agent.service.ts
+++ b/apps/backend/src/aims/services/agent.service.ts
@@ -18,11 +18,16 @@ export class AgentService {
   }
 
   async findAll(): Promise<Agent[]> {
-    return this.agentRepository.find();
+    return this.agentRepository.find({
+      relations: ['clauses', 'assessments', 'assessments.clause'],
+    });
   }
 
   async findOne(id: string): Promise<Agent> {
-    const agent = await this.agentRepository.findOne({ where: { id } });
+    const agent = await this.agentRepository.findOne({
+      where: { id },
+      relations: ['clauses', 'assessments', 'assessments.clause'],
+    });
     if (!agent) {
       throw new NotFoundException(`Agent with ID ${id} not found`);
     }

--- a/apps/frontend/src/app/aims/incidents/page.tsx
+++ b/apps/frontend/src/app/aims/incidents/page.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import Layout from '../../../features/aims/components/Layout';
 import IncidentsPage from '../../../features/aims/pages/IncidentsPage';
+import React from 'react';
 
 export default function Page() {
   return (

--- a/apps/frontend/src/features/aims/pages/RegistryPage.tsx
+++ b/apps/frontend/src/features/aims/pages/RegistryPage.tsx
@@ -1,8 +1,22 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { FaRobot, FaEye, FaEdit, FaTimes } from "react-icons/fa";
-import { getAgents, createAgent, updateAgent, CreateAgentDto, Agent } from "../services/aims-api";
+import { FaRobot, FaEye, FaEdit, FaTimes, FaBook, FaLink, FaTrash, FaPencilAlt, FaCog } from "react-icons/fa";
+import { 
+  getAgents, 
+  getClauses,
+  createAgent, 
+  updateAgent, 
+  createAgentClauseAssessment,
+  updateAgentClauseAssessment,
+  deleteAgentClauseAssessment,
+  CreateAgentDto, 
+  Agent, 
+  Clause,
+  CreateAgentClauseAssessmentDto,
+  UpdateAgentClauseAssessmentDto,
+  AgentClauseAssessment
+} from "../services/aims-api";
 import { toast } from "../../../../libs/toast";
 
 export default function RegistryPage() {
@@ -19,14 +33,37 @@ export default function RegistryPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [agents, setAgents] = useState<Agent[]>([]);
   
-  // Dummy agent types for dropdown
+  // State for managing clauses modal
+  const [isManageClausesModalOpen, setIsManageClausesModalOpen] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
+  const [clauseLinkFormData, setClauseLinkFormData] = useState<CreateAgentClauseAssessmentDto>({
+    agentId: "",
+    clauseId: "",
+    evidenceLink: ""
+  });
+  const [clauses, setClauses] = useState<Clause[]>([]);
+  const [loadingClauses, setLoadingClauses] = useState(false);
+  
+  // State for edit evidence link modal
+  const [isEditEvidenceLinkModalOpen, setIsEditEvidenceLinkModalOpen] = useState(false);
+  const [currentAssessment, setCurrentAssessment] = useState<AgentClauseAssessment | null>(null);
+  const [updatedEvidenceLink, setUpdatedEvidenceLink] = useState("");
+  
+  // Dummy agent types for dropdown : TODO: replace with actual agent types from the backend
   const agentTypes = [
-    "Chatbot",
-    "Security AI",
-    "Recommendation AI",
-    "NLP AI",
-    "Industrial AI",
-    "Computer Vision"
+    "Chat Agent",
+    "Document Summarization Agent",
+    "Code Generation Agent",
+    "Data Analysis Agent",
+    "RAG Agent - Document Retrieval",
+    "RAG Agent - Code Retrieval",
+    "RAG Agent - Image Retrieval",
+    "RAG Agent - Video Retrieval",
+    "RAG Agent - Audio Retrieval",
+    "RAG Agent - General Retrieval",
+    "RAG Agent - Multi-Modal Retrieval",
+    "Computer Vision Agent",
+    "General Purpose Agent"
   ];
 
   // Fetch agents data from API
@@ -43,6 +80,21 @@ export default function RegistryPage() {
       console.error("Failed to fetch agents:", err);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Fetch clauses data from API
+  const fetchClauses = async () => {
+    setLoadingClauses(true);
+    
+    try {
+      const data = await getClauses();
+      setClauses(data);
+    } catch (err) {
+      console.error("Failed to fetch clauses:", err);
+      toast.error("Failed to load clauses. Please try again.");
+    } finally {
+      setLoadingClauses(false);
     }
   };
 
@@ -125,6 +177,135 @@ export default function RegistryPage() {
     setFormData({ name: "", type: "", description: "" });
   };
 
+  // Handle opening the manage clauses modal
+  const handleOpenManageClausesModal = (agent: Agent) => {
+    setSelectedAgent(agent);
+    setClauseLinkFormData({
+      agentId: String(agent.id),
+      clauseId: "",
+      evidenceLink: ""
+    });
+    setIsManageClausesModalOpen(true);
+    
+    // Fetch clauses if we haven't already
+    if (clauses.length === 0) {
+      fetchClauses();
+    }
+  };
+  
+  // Handle closing the manage clauses modal
+  const handleCloseManageClausesModal = () => {
+    setIsManageClausesModalOpen(false);
+    setSelectedAgent(null);
+    setClauseLinkFormData({
+      agentId: "",
+      clauseId: "",
+      evidenceLink: ""
+    });
+  };
+  
+  // Handle input change for clause link form
+  const handleClauseLinkInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setClauseLinkFormData((prev) => ({ ...prev, [name]: value }));
+  };
+  
+  // Handle submission of clause link form
+  const handleClauseLinkSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    
+    try {
+      await createAgentClauseAssessment(clauseLinkFormData);
+      
+      // Refresh the agent list to include the new assessment
+      await fetchAgents();
+      
+      toast.success("Clause successfully linked to agent");
+      
+      // Reset form but keep the modal open for more edits
+      setClauseLinkFormData({
+        agentId: selectedAgent ? String(selectedAgent.id) : "",
+        clauseId: "",
+        evidenceLink: ""
+      });
+      
+    } catch (err) {
+      console.error("Error linking clause to agent:", err);
+      
+      // Show error toast
+      toast.error(err instanceof Error ? err.message : "Failed to link clause to agent. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Handle opening the edit evidence link modal
+  const handleOpenEditEvidenceLinkModal = (assessment: AgentClauseAssessment) => {
+    setCurrentAssessment(assessment);
+    setUpdatedEvidenceLink(assessment.evidenceLink || "");
+    setIsEditEvidenceLinkModalOpen(true);
+  };
+  
+  // Handle delete assessment confirmation and deletion
+  const handleDeleteAssessment = async (assessmentId: string) => {
+    if (window.confirm("Are you sure you want to remove this clause from the agent?")) {
+      setIsSubmitting(true);
+      
+      try {
+        await deleteAgentClauseAssessment(assessmentId);
+        
+        // Refresh the agent list to remove the deleted assessment
+        await fetchAgents();
+        
+        toast.success("Clause successfully unlinked from agent");
+      } catch (err) {
+        console.error("Error unlinking clause from agent:", err);
+        
+        // Show error toast
+        toast.error(err instanceof Error ? err.message : "Failed to unlink clause from agent. Please try again.");
+      } finally {
+        setIsSubmitting(false);
+      }
+    }
+  };
+  
+  // Handle evidence link update submission
+  const handleUpdateEvidenceLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!currentAssessment) return;
+    
+    setIsSubmitting(true);
+    
+    try {
+      const updateData: UpdateAgentClauseAssessmentDto = {
+        evidenceLink: updatedEvidenceLink
+      };
+      
+      await updateAgentClauseAssessment(currentAssessment.id, updateData);
+      
+      // Refresh the agent list to show the updated evidence link
+      await fetchAgents();
+      
+      toast.success("Evidence link successfully updated");
+      
+      // Close modal
+      setIsEditEvidenceLinkModalOpen(false);
+      setCurrentAssessment(null);
+      setUpdatedEvidenceLink("");
+    } catch (err) {
+      console.error("Error updating evidence link:", err);
+      
+      // Show error toast
+      toast.error(err instanceof Error ? err.message : "Failed to update evidence link. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
@@ -182,6 +363,69 @@ export default function RegistryPage() {
                 <p className="text-sm text-gray-500 mb-6">
                   {agent.description}
                 </p>
+                
+                {/* Scoped Clauses Section - modified to make only gear icon and "manage" text clickable */}
+                <div className="mb-6">
+                  <div className="flex items-center mb-2">
+                    <FaBook className="h-4 w-4 text-gray-500 mr-2" />
+                    <h4 className="text-sm font-medium text-gray-700">Scoped Clauses</h4>
+                    <div className="flex items-center ml-2 cursor-pointer hover:text-primary-600 transition-colors">
+                      <FaCog 
+                        className="h-3.5 w-3.5 text-gray-400 hover:text-primary-600 transition-colors" 
+                        onClick={() => handleOpenManageClausesModal(agent)}
+                      />
+                      <span 
+                        className="text-xs text-gray-400 ml-1 hover:text-primary-600"
+                        onClick={() => handleOpenManageClausesModal(agent)}
+                      >(manage)</span>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {agent.scopedAssessments && agent.scopedAssessments.length > 0 ? (
+                      agent.scopedAssessments.map(assessment => {
+                        // Try to get the clause title from either the assessment or the clauses array
+                        const clauseTitle = assessment.clause?.title || 
+                          clauses.find(c => c.id === assessment.clauseId)?.title || 
+                          `Clause ${assessment.clauseId}`;
+                          
+                        return (
+                          <div key={assessment.id} className="inline-flex items-center group">
+                            <span 
+                              className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
+                              title={clauseTitle}
+                            >
+                              {assessment.clauseId}
+                            </span>
+                            
+                            {assessment.evidenceLink && (
+                              <a 
+                                href={assessment.evidenceLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="ml-1 text-blue-600 hover:text-blue-800"
+                                title="View evidence"
+                              >
+                                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                </svg>
+                              </a>
+                            )}
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <div className="flex items-center">
+                        <span className="text-sm text-gray-400">No clauses scoped</span>
+                        <button 
+                          className="ml-1 text-xs text-primary-600 hover:text-primary-800 hover:underline"
+                          onClick={() => handleOpenManageClausesModal(agent)}
+                        >
+                          (add)
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
 
                 <div className="flex space-x-3">
                   <button className="flex-1 inline-flex justify-center items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
@@ -298,6 +542,244 @@ export default function RegistryPage() {
                         ? isEditMode ? "Updating..." : "Creating..." 
                         : isEditMode ? "Update Agent" : "Create Agent"
                       }
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Manage Clauses Modal */}
+      {isManageClausesModalOpen && selectedAgent && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            {/* Background overlay */}
+            <div 
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
+              onClick={handleCloseManageClausesModal}
+            ></div>
+
+            {/* Modal panel */}
+            <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="flex justify-between items-center mb-5">
+                  <h3 className="text-lg font-medium text-gray-900">
+                    Manage Scoped Clauses for {selectedAgent.name}
+                  </h3>
+                  <button 
+                    onClick={handleCloseManageClausesModal}
+                    className="text-gray-400 hover:text-gray-500 focus:outline-none"
+                  >
+                    <FaTimes className="h-5 w-5" />
+                  </button>
+                </div>
+
+                {/* Current scoped clauses */}
+                {selectedAgent.scopedAssessments && selectedAgent.scopedAssessments.length > 0 && (
+                  <div className="mb-8">
+                    <h4 className="text-sm font-medium text-gray-700 mb-3">Current Scoped Clauses</h4>
+                    <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                      {selectedAgent.scopedAssessments.map(assessment => {
+                        // Try to get the clause title from either the assessment or the clauses array
+                        const clauseTitle = assessment.clause?.title || 
+                          clauses.find(c => c.id === assessment.clauseId)?.title || 
+                          `Clause ${assessment.clauseId}`;
+                          
+                        return (
+                          <div 
+                            key={assessment.id} 
+                            className="flex justify-between items-center py-2 px-3 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors duration-200"
+                          >
+                            <div className="flex items-center overflow-hidden">
+                              <span 
+                                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 mr-2 flex-shrink-0"
+                                title={clauseTitle}
+                              >
+                                {assessment.clauseId}
+                              </span>
+                              {assessment.evidenceLink ? (
+                                <div className="flex items-center overflow-hidden">
+                                  <a 
+                                    href={assessment.evidenceLink}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 text-sm hover:text-blue-800 truncate max-w-[150px]"
+                                    title={assessment.evidenceLink}
+                                  >
+                                    {assessment.evidenceLink.replace(/^https?:\/\//, '').substring(0, 20)}
+                                    {assessment.evidenceLink.length > 20 ? '...' : ''}
+                                  </a>
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleOpenEditEvidenceLinkModal(assessment);
+                                    }}
+                                    className="ml-2 text-gray-400 hover:text-gray-600 focus:outline-none flex-shrink-0"
+                                    title="Edit evidence link"
+                                  >
+                                    <FaPencilAlt className="h-3 w-3" />
+                                  </button>
+                                </div>
+                              ) : (
+                                <span className="text-sm text-gray-400">No evidence link</span>
+                              )}
+                            </div>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteAssessment(assessment.id);
+                              }}
+                              className="text-gray-400 hover:text-red-600 focus:outline-none ml-2 flex-shrink-0"
+                              title="Remove clause"
+                            >
+                              <FaTrash className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Divider line */}
+                <div className="border-t border-gray-200 mb-6 -mx-4 px-4"></div>
+
+                {/* Add clause form */}
+                <div className="mb-4">
+                  <h4 className="text-sm font-medium text-gray-700 mb-3">Scope New Clause</h4>
+                  <form onSubmit={handleClauseLinkSubmit}>
+                    <div className="mb-4">
+                      <label htmlFor="clauseId" className="block text-sm font-medium text-gray-700 mb-1">
+                        Select Clause
+                      </label>
+                      {loadingClauses ? (
+                        <div className="text-sm text-gray-500">Loading clauses...</div>
+                      ) : (
+                        <select
+                          id="clauseId"
+                          name="clauseId"
+                          value={clauseLinkFormData.clauseId}
+                          onChange={handleClauseLinkInputChange}
+                          required
+                          className="shadow-sm focus:ring-primary-500 focus:border-primary-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                        >
+                          <option value="">Select a clause to scope</option>
+                          {clauses.map((clause) => (
+                            <option key={clause.id} value={clause.id}>
+                              {clause.id} - {clause.title}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+
+                    <div className="mb-6">
+                      <label htmlFor="evidenceLink" className="block text-sm font-medium text-gray-700 mb-1">
+                        Evidence Link (Optional)
+                      </label>
+                      <input
+                        type="url"
+                        id="evidenceLink"
+                        name="evidenceLink"
+                        value={clauseLinkFormData.evidenceLink || ""}
+                        onChange={handleClauseLinkInputChange}
+                        className="shadow-sm focus:ring-primary-500 focus:border-primary-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                        placeholder="https://example.com/evidence"
+                      />
+                    </div>
+
+                    <div className="flex justify-end">
+                      <button
+                        type="submit"
+                        disabled={isSubmitting || !clauseLinkFormData.clauseId}
+                        className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:bg-primary-400 disabled:cursor-not-allowed"
+                      >
+                        {isSubmitting ? "Adding..." : "Add Clause"}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+
+                <div className="mt-8 pt-4 border-t border-gray-200 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleCloseManageClausesModal}
+                    className="inline-flex justify-center py-2 px-4 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                  >
+                    Done
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Edit Evidence Link Modal */}
+      {isEditEvidenceLinkModalOpen && currentAssessment && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            {/* Background overlay */}
+            <div 
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
+              onClick={() => setIsEditEvidenceLinkModalOpen(false)}
+            ></div>
+
+            {/* Modal panel */}
+            <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="flex justify-between items-center mb-4">
+                  <h3 className="text-lg font-medium text-gray-900">
+                    Update Evidence Link
+                  </h3>
+                  <button 
+                    onClick={() => setIsEditEvidenceLinkModalOpen(false)}
+                    className="text-gray-400 hover:text-gray-500 focus:outline-none"
+                  >
+                    <FaTimes className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <form onSubmit={handleUpdateEvidenceLink}>
+                  <div className="mb-2">
+                    <span className="block text-sm font-medium text-gray-700 mb-1">
+                      Clause:
+                    </span>
+                    <span className="block text-sm text-gray-900">
+                      {currentAssessment.clauseId}
+                    </span>
+                  </div>
+
+                  <div className="mb-4">
+                    <label htmlFor="evidenceLink" className="block text-sm font-medium text-gray-700 mb-1">
+                      Evidence Link
+                    </label>
+                    <input
+                      type="url"
+                      id="evidenceLink"
+                      value={updatedEvidenceLink || ""}
+                      onChange={(e) => setUpdatedEvidenceLink(e.target.value)}
+                      className="shadow-sm focus:ring-primary-500 focus:border-primary-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                      placeholder="https://example.com/evidence"
+                    />
+                  </div>
+
+                  <div className="mt-6 flex justify-end space-x-3">
+                    <button
+                      type="button"
+                      onClick={() => setIsEditEvidenceLinkModalOpen(false)}
+                      className="inline-flex justify-center py-2 px-4 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:bg-primary-400 disabled:cursor-not-allowed"
+                    >
+                      {isSubmitting ? "Updating..." : "Update Link"}
                     </button>
                   </div>
                 </form>

--- a/apps/frontend/src/features/aims/services/aims-api.ts
+++ b/apps/frontend/src/features/aims/services/aims-api.ts
@@ -7,6 +7,8 @@ export interface Agent {
   name: string;
   type: string;
   description: string;
+  clauses?: Clause[];
+  scopedAssessments?: AgentClauseAssessment[];
 }
 
 export interface CreateAgentDto {
@@ -35,6 +37,26 @@ export interface CreateClauseDto {
 
 export interface UpdateClauseDto {
   status?: 'pending' | 'gap' | 'compliant' | 'non_compliant';
+  evidenceLink?: string | null;
+}
+
+export interface AgentClauseAssessment {
+  id: string;
+  agentId: string;
+  clauseId: string;
+  evidenceLink?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  clause?: Clause;
+}
+
+export interface CreateAgentClauseAssessmentDto {
+  agentId: string;
+  clauseId: string;
+  evidenceLink?: string | null;
+}
+
+export interface UpdateAgentClauseAssessmentDto {
   evidenceLink?: string | null;
 }
 
@@ -182,6 +204,73 @@ export async function updateClause(id: string, clause: UpdateClauseDto): Promise
     return await response.json();
   } catch (error) {
     console.error('Error updating clause:', error);
+    throw error;
+  }
+}
+
+/**
+ * Creates a new agent-clause assessment linkage
+ */
+export async function createAgentClauseAssessment(assessment: CreateAgentClauseAssessmentDto): Promise<AgentClauseAssessment> {
+  try {
+    const response = await fetch('http://localhost:3001/api/agent-clause-assessments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(assessment),
+    });
+    
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    
+    return await response.json();
+  } catch (error) {
+    console.error('Error creating agent-clause assessment:', error);
+    throw error;
+  }
+}
+
+/**
+ * Updates an existing agent-clause assessment
+ */
+export async function updateAgentClauseAssessment(id: string, assessment: UpdateAgentClauseAssessmentDto): Promise<AgentClauseAssessment> {
+  try {
+    const response = await fetch(`http://localhost:3001/api/agent-clause-assessments/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(assessment),
+    });
+    
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    
+    return await response.json();
+  } catch (error) {
+    console.error('Error updating agent-clause assessment:', error);
+    throw error;
+  }
+}
+
+/**
+ * Deletes an agent-clause assessment
+ */
+export async function deleteAgentClauseAssessment(id: string): Promise<void> {
+  try {
+    const response = await fetch(`http://localhost:3001/api/agent-clause-assessments/${id}`, {
+      method: 'DELETE',
+    });
+    
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    
+  } catch (error) {
+    console.error('Error deleting agent-clause assessment:', error);
     throw error;
   }
 } 


### PR DESCRIPTION
This PR introduces scoped clause management for AI agents as part of the broader ISO/IEC 42001 compliance framework. The implementation allows each agent to be linked to one or more ISO clauses with optional evidence, directly from the Registry UI.

✅ Features Included

🧠 Agent–Clause Association (Scoping)
	•	Agents can now be scoped to one or more ISO 42001 clauses.
	•	Evidence links (URLs) can be optionally attached to each scoped clause.

🖥️ Registry Page Enhancements
	•	“Scoped Clauses” section added to each agent card.
	•	Clause badges show clause ID.
	•	External link icon appears if an evidence URL exists.
	•	Hovering over a badge shows the full clause title via tooltip.
	•	Added subtle hover UI on clause rows for responsiveness.
	•	Tooltips now appear on all edit/delete icons and evidence links.

🛠️ Scoped Clause Management Modal
	•	Replaced “Link Clause” button with a more intuitive “Scoped Clauses (manage)” section.
	•	Clicking (manage) or the gear icon opens a modal to:
	•	View currently scoped clauses.
	•	Add new clause + optional evidence.
	•	Edit existing evidence links.
	•	Delete scoped clauses with confirmation.
	•	Visual clarity and spacing improved using Tailwind CSS:
	•	Scrollable clause list
	•	Divider between sections
	•	Consistent paddings/margins

🧪 Backend/API Updates
	•	agent-clause-assessments endpoints implemented:
	•	POST to create assessment (agentId, clauseId, optional evidenceLink)
	•	PATCH to update evidenceLink
	•	DELETE to remove scoped clause from agent
	•	Backend AgentService enhanced to return scoped assessments with clauses.
	•	API response includes scopedAssessments for full context on agent cards.

🧩 Data Integrity & Safeguards
	•	Duplicate clause IDs are allowed per agent (multi-source evidence), but UI now provides edit/delete to manage accidental duplicates.
	•	Added proper error handling, toast feedback, and confirmation prompts.

📸 Screenshots
![image](https://github.com/user-attachments/assets/50ebc3b1-82a0-40ee-b951-eb858db56516)
![image](https://github.com/user-attachments/assets/1974acd7-cc58-4e22-84b1-077936c39081)

